### PR TITLE
Django 3.0 compatability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     packages=[
         'timezone_field',
     ],
-    install_requires=['django>=1.11', 'pytz'],
+    install_requires=['django>=1.11', 'pytz', 'six'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,13 +1,13 @@
 from __future__ import absolute_import
 
 import pytz
+import six
 
 from django import forms
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.migrations.writer import MigrationWriter
 from django.test import TestCase
-from django.utils import six
 
 from timezone_field import TimeZoneField, TimeZoneFormField
 from timezone_field.utils import add_gmt_offset_to_choices

--- a/timezone_field/fields.py
+++ b/timezone_field/fields.py
@@ -1,8 +1,8 @@
 import pytz
+import six
 
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils import six
 from django.utils.encoding import force_text
 
 from timezone_field.utils import is_pytz_instance, add_gmt_offset_to_choices

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ envlist =
     coverage-clean,
     py27-django111-{sqlite,postgres},
     py34-{django111,django20}-{sqlite,postgres},
-    py35-{django111,django20,django21,django22}-{sqlite,postgres},
-    py36-{django111,django20,django21,django22}-{sqlite,postgres},
-    py37-{django111,django20,django21,django22}-{sqlite,postgres},
+    py35-{django111,django20,django21,django22,django30}-{sqlite,postgres},
+    py36-{django111,django20,django21,django22,django30}-{sqlite,postgres},
+    py37-{django111,django20,django21,django22,django30}-{sqlite,postgres},
     coverage-report,
     py37-flake8
 
@@ -17,6 +17,7 @@ deps =
     django20: django>=2.0,<2.1
     django21: django>=2.1,<2.2
     django22: django>=2.2,<2.3
+    django30: django>=3.0b
     postgres: psycopg2-binary
 setenv =
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
`six` is no longer imported into `django.utils`, so this library needs to declare it as a requirement.